### PR TITLE
Fix bug where already decoded json would throw error

### DIFF
--- a/src/fields/JasonField.php
+++ b/src/fields/JasonField.php
@@ -420,12 +420,14 @@ class JasonField extends Field
     public function validateIsJSON(ElementInterface $element, array $params = null)
     {
         $value = $element->getFieldValue($this->handle);
-        
-        $json = json_decode($value); 
 
-        if ($json === null) {
-        // JSON cannot be decoded
-            $element->addError($this->handle, Craft::t('site', 'Not valid JSON.'));
+        if (!is_array($value)) {
+            $json = json_decode($value);
+
+            if ($json === null) {
+                // JSON cannot be decoded
+                $element->addError($this->handle, Craft::t('site', 'Not valid JSON.'));
+            }
         }
     }
 }


### PR DESCRIPTION
When using GraphQL it seems its already decoded in the validation message:

```php
[
  "debugMessage" => "json_decode() expects parameter 1 to be string, array given",
  "file" => "/var/www/html/craft/vendor/chasegiunta/craft-jason/src/fields/JasonField.php",
  "line" => 425
]
```