### PR TITLE
Adds Craft 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "craftcms/cms": "^4.0.0",
+    "craftcms/cms": "^4.0.0|^5.0.0",
     "php": "^8.0.2"
   },
   "autoload": {


### PR DESCRIPTION
This seemed sufficient to add Craft 5 support. The field appears to be working fine. No major version bump required, unless you want it!

Fixes #151.